### PR TITLE
Update appointment buttons: Confirm, Done, Cancel, Set as Draft

### DIFF
--- a/ docs/GitHub_Instructions.pdf
+++ b/ docs/GitHub_Instructions.pdf
@@ -12,8 +12,8 @@ git checkout -b feature/<Your Module Task name>
 ## 4. Stage and Commit Changes 
  git add .
  git commit -m "Implemented <task_name> module with required views and fields"
-## 5. Push Your Branch to GitHub
-  git push origin <your_branch_name>
+## 5. Push -u origin <Your Branch> to GitHubgit 
+git push origin <your_branch_name>
 ## 6. Create a Pull Request (PR)
 Go to the GitHub repository.
 Click Compare & pull request on your branch.

--- a/views/appointment_views.xml
+++ b/views/appointment_views.xml
@@ -16,10 +16,25 @@
                     </group>
                 </sheet>
                 <header>
-                    <button string="Confirm" type="object" name="action_confirm" class="btn-primary"/>
-                    <button string="Done" type="object" name="action_done" class="btn-success"/>
-                    <button string="Cancel" type="object" name="action_cancel" class="btn-danger"/>
-                    <button string="Set to Draft" type="object" name="action_draft" class="btn-secondary"/>
+                    <!-- يظهر Confirm فقط إذا كانت الحالة draft -->
+                    <button name="action_confirm" type="object" string="✅ Confirm"
+                        class="btn-primary"
+                        invisible="state != 'draft'"/>
+                    
+                    <!-- يظهر Done فقط إذا كانت الحالة confirmed -->
+                    <button name="action_done" type="object" string="✅ Done"
+                        class="btn-success"
+                        invisible="state != 'confirmed'"/>
+                    
+                    <!-- يظهر Cancel فقط إذا كانت الحالة done -->
+                    <button name="action_cancel" type="object" string="❌ Cancel"
+                        class="btn-danger"
+                        invisible="state != 'done'"/>
+                    
+                    <!-- زر Draft يظهر فقط لو حبيت ترجع الحالة الملغاة -->
+                    <button name="action_draft" type="object" string="🔄 Set to Draft"
+                        class="btn-secondary"
+                        invisible="state != 'cancelled'"/>
                 </header>
             </form>
         </field>
@@ -39,14 +54,5 @@
         </field>
     </record>
 
-    <record id="action_appointment" model="ir.actions.act_window">
-        <field name="name">Appointments</field>
-        <field name="res_model">hospital.appointment</field>
-        <field name="view_mode">list,form</field>
-    </record>
-
-    <menuitem id="menu_hospital_appointments" 
-              name="Appointments" 
-              parent="menu_hospital_root" 
-              action="action_appointment"/>
+   
 </odoo>

--- a/views/appointment_views.xml
+++ b/views/appointment_views.xml
@@ -16,26 +16,27 @@
                     </group>
                 </sheet>
                 <header>
-                    <!-- يظهر Confirm فقط إذا كانت الحالة draft -->
-                    <button name="action_confirm" type="object" string="✅ Confirm"
-                        class="btn-primary"
-                        invisible="state != 'draft'"/>
-                    
-                    <!-- يظهر Done فقط إذا كانت الحالة confirmed -->
-                    <button name="action_done" type="object" string="✅ Done"
-                        class="btn-success"
-                        invisible="state != 'confirmed'"/>
-                    
-                    <!-- يظهر Cancel فقط إذا كانت الحالة done -->
-                    <button name="action_cancel" type="object" string="❌ Cancel"
-                        class="btn-danger"
-                        invisible="state != 'done'"/>
-                    
-                    <!-- زر Draft يظهر فقط لو حبيت ترجع الحالة الملغاة -->
-                    <button name="action_draft" type="object" string="🔄 Set to Draft"
-                        class="btn-secondary"
-                        invisible="state != 'cancelled'"/>
-                </header>
+    <!-- يظهر Confirm فقط إذا كانت الحالة draft -->
+    <button name="action_confirm" type="object" string="✅ Confirm"
+        class="btn-primary"
+        invisible="state != 'draft'"/>
+
+    <!-- يظهر Done فقط إذا كانت الحالة confirmed -->
+    <button name="action_done" type="object" string="✅ Done"
+        class="btn-success"
+        invisible="state != 'confirmed'"/>
+
+    <!-- يظهر Cancel فقط إذا كانت الحالة draft أو confirmed -->
+    <button name="action_cancel" type="object" string="❌ Cancel"
+        class="btn-danger"
+        invisible="not (state == 'draft' or state == 'confirmed')"/>
+
+    <!-- زر Draft يظهر فقط لو الحالة cancelled -->
+    <button name="action_draft" type="object" string="🔄 Set to Draft"
+        class="btn-secondary"
+        invisible="state != 'cancelled'"/>
+</header>
+
             </form>
         </field>
     </record>

--- a/views/hospital_menu.xml
+++ b/views/hospital_menu.xml
@@ -70,5 +70,16 @@
               parent="menu_hospital_root" 
               action="action_staff"/>
 
+        <record id="action_appointment" model="ir.actions.act_window">
+        <field name="name">Appointments</field>
+        <field name="res_model">hospital.appointment</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="menu_hospital_appointments" 
+              name="Appointments" 
+              parent="menu_hospital_root" 
+              action="action_appointment"/>
+
 
 </odoo>


### PR DESCRIPTION
This pull request modifies the behavior of the appointment action buttons.  
Specifically, the following buttons were updated:  

- Confirm
-  Done  
- Cancel  
- Set as Draft  

The changes ensure that these buttons appear and function correctly based on the appointment's current state.

Closes #26
